### PR TITLE
Post Category Service Unit 테스트

### DIFF
--- a/backend/src/posts/posts-category.service.spec.ts
+++ b/backend/src/posts/posts-category.service.spec.ts
@@ -35,6 +35,14 @@ const mockPostCategoryRepository = () => {
         });
       }
 
+      if (where.id) {
+        categories.forEach((category) => {
+          if (category.id === where.id) {
+            existingPostCategory = category;
+          }
+        });
+      }
+
       return existingPostCategory;
     }),
     remove: jest.fn(),
@@ -93,5 +101,17 @@ describe('PostsCategoryService', () => {
     await expect(
       service.updatePostCategory(9999, { type: 'New' }),
     ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('should update a post category', async () => {
+    const postCategory = await service.createPostCategory({ type });
+
+    console.log(postCategory);
+    const updatedPostCategory = await service.updatePostCategory(
+      postCategory.id,
+      { type: 'Updated' },
+    );
+
+    expect(updatedPostCategory.type).toEqual('Updated');
   });
 });

--- a/backend/src/posts/posts-category.service.spec.ts
+++ b/backend/src/posts/posts-category.service.spec.ts
@@ -19,7 +19,9 @@ const mockPostCategoryRepository = () => {
       categories.push(category);
       return category;
     }),
-    find: jest.fn(),
+    find: jest.fn().mockImplementation(() => {
+      return categories;
+    }),
     findOne: jest.fn().mockImplementation((query) => {
       const where = query.where;
 
@@ -76,5 +78,14 @@ describe('PostsCategoryService', () => {
     await expect(service.createPostCategory({ type })).rejects.toBeInstanceOf(
       BadRequestException,
     );
+  });
+
+  it('should return post categories list', async () => {
+    await service.createPostCategory({ type: '자유게시판' });
+    await service.createPostCategory({ type: '공지사항' });
+    await service.createPostCategory({ type: '운영게시판' });
+
+    const categories = await service.findAllPostCategories();
+    expect(categories).toHaveLength(3);
   });
 });

--- a/backend/src/posts/posts-category.service.spec.ts
+++ b/backend/src/posts/posts-category.service.spec.ts
@@ -69,4 +69,12 @@ describe('PostsCategoryService', () => {
 
     expect(postCategory.type).toEqual(type);
   });
+
+  it('throws exception if user tries to create a new post category whose type is already exists.', async () => {
+    await service.createPostCategory({ type });
+
+    await expect(service.createPostCategory({ type })).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
 });

--- a/backend/src/posts/posts-category.service.spec.ts
+++ b/backend/src/posts/posts-category.service.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PostCategory } from './entities/post-category.entity';
+import { PostsCategoryService } from './posts-category.service';
+
+const mockPostCategoryRepository = () => {
+  const categories: PostCategory[] = [];
+
+  return {
+    create: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    remove: jest.fn(),
+  };
+};
+
+describe('PostsCategoryService', () => {
+  let service: PostsCategoryService;
+  let postCategoryRepository: Repository<PostCategory>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PostsCategoryService,
+        {
+          provide: getRepositoryToken(PostCategory),
+          useValue: mockPostCategoryRepository(),
+        },
+      ],
+    }).compile();
+
+    service = module.get<PostsCategoryService>(PostsCategoryService);
+    postCategoryRepository = module.get(getRepositoryToken(PostCategory));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/posts/posts-category.service.spec.ts
+++ b/backend/src/posts/posts-category.service.spec.ts
@@ -45,7 +45,15 @@ const mockPostCategoryRepository = () => {
 
       return existingPostCategory;
     }),
-    remove: jest.fn(),
+    remove: jest.fn().mockImplementation((category) => {
+      const index = categories.findIndex((c, index) => {
+        if (c.id === category.id) {
+          return true;
+        }
+      });
+
+      categories.splice(index, 1);
+    }),
   };
 };
 
@@ -106,7 +114,6 @@ describe('PostsCategoryService', () => {
   it('should update a post category', async () => {
     const postCategory = await service.createPostCategory({ type });
 
-    console.log(postCategory);
     const updatedPostCategory = await service.updatePostCategory(
       postCategory.id,
       { type: 'Updated' },
@@ -119,5 +126,16 @@ describe('PostsCategoryService', () => {
     await expect(service.deletePostCategory(9999)).rejects.toBeInstanceOf(
       NotFoundException,
     );
+  });
+
+  it('should delete a post category with a given id', async () => {
+    const { id } = await service.createPostCategory({ type });
+
+    const categoriesBeforeDelete = await service.findAllPostCategories();
+    expect(categoriesBeforeDelete.length).toEqual(1);
+
+    await service.deletePostCategory(id);
+    const categories = await service.findAllPostCategories();
+    expect(categories.length).toEqual(0);
   });
 });

--- a/backend/src/posts/posts-category.service.spec.ts
+++ b/backend/src/posts/posts-category.service.spec.ts
@@ -114,4 +114,10 @@ describe('PostsCategoryService', () => {
 
     expect(updatedPostCategory.type).toEqual('Updated');
   });
+
+  it('throws exception if user tries to delete non-existing post category.', async () => {
+    await expect(service.deletePostCategory(9999)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
 });

--- a/backend/src/posts/posts-category.service.spec.ts
+++ b/backend/src/posts/posts-category.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -87,5 +87,11 @@ describe('PostsCategoryService', () => {
 
     const categories = await service.findAllPostCategories();
     expect(categories).toHaveLength(3);
+  });
+
+  it('throws exception if user tries to updte a non-existing post', async () => {
+    await expect(
+      service.updatePostCategory(9999, { type: 'New' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
   });
 });


### PR DESCRIPTION
# Topic

Post Category Service Unit 테스트

## Description

Post Category Service Unit test

- createPostCategory 테스트
- updatePostCategory 테스트
- deletePostCategory 테스트


## Output

test: post category unit test 환경 세팅
test: post category 생성 성공 테스트
test: 중복되는 type의 post category 생성 시도시 BadRequestException 테스트
test: post category list 조회 테스트
test: 존재하지 않는 Post category id로 수정 시도시 NotFoundException 테스트
test: post category 수정 성공 테스트
test: 존재하지 않는 post category id로 삭제 시도시 NotFoundException 테스트
test: post category 삭제 성공 테스트