### PR TITLE
User API response serialization 구현

### DIFF
--- a/backend/src/interceptors/serialize.interceptor.ts
+++ b/backend/src/interceptors/serialize.interceptor.ts
@@ -1,0 +1,35 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  NestInterceptor,
+  UseInterceptors,
+} from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+interface ClassConstructor {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  new (...args: any[]): {};
+}
+
+export function Serialize(dto: ClassConstructor) {
+  return UseInterceptors(new SerializeInterceptor(dto));
+}
+
+export class SerializeInterceptor implements NestInterceptor {
+  constructor(private dto: any) {}
+
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<any>,
+  ): Observable<any> | Promise<Observable<any>> {
+    return next.handle().pipe(
+      map((data: any) => {
+        return plainToInstance(this.dto, data, {
+          excludeExtraneousValues: true,
+        });
+      }),
+    );
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -11,7 +11,11 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.setGlobalPrefix(PREFIX);
 
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+    }),
+  );
 
   const docsConfig = new DocumentBuilder()
     .setTitle('waynehills subject')

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
 import {
   IsEmail,
   IsEnum,
@@ -42,4 +43,21 @@ export class CreateUserDto {
   @IsString()
   @IsNotEmpty()
   phone: string;
+}
+
+export class CreateUserResponseDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  email: string;
+
+  @Expose()
+  gender: string;
+
+  @Expose()
+  phone: string;
+
+  @Expose()
+  role: string;
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -14,7 +14,7 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
-import { CreateUserDto } from './dto/create-user.dto';
+import { CreateUserDto, CreateUserResponseDto } from './dto/create-user.dto';
 import {
   ApiCookieAuth,
   ApiCreatedResponse,
@@ -25,6 +25,7 @@ import { User } from './entities/user.entity';
 import { AuthGuard } from '@nestjs/passport';
 import { GetCurrentUserId } from '../commons/decorators/get.current-userId.decorator';
 import { Response } from 'express';
+import { Serialize } from '../interceptors/serialize.interceptor';
 
 @Controller('users')
 @ApiTags('Users API')
@@ -32,6 +33,7 @@ export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Post()
+  @Serialize(CreateUserResponseDto)
   @ApiOperation({ summary: '유저 생성 API', description: '유저를 생성합니다.' })
   @ApiCreatedResponse({ description: '유저를 생성합니다.', type: User })
   createUser(@Body() createUserDto: CreateUserDto): Promise<User> {
@@ -39,6 +41,7 @@ export class UsersController {
   }
 
   @Get(':id')
+  @Serialize(CreateUserResponseDto)
   @ApiOperation({ summary: '유저 조회 API', description: '유저를 조회합니다.' })
   @ApiCreatedResponse({ description: '유저를 조회합니다.', type: User })
   findOneUser(@Param('id', ParseIntPipe) id: number): Promise<User> {


### PR DESCRIPTION
# Topic

User API response serialization 구현

## Description

response 에서 삭제된 필드
- password
- createdAt
- updatedAt
- lastAccessedAt
- isDeleted

Serialization이 적용된 API
- POST /users
- GET /users/:id

## Output
feat: Users API response serialization 구현
